### PR TITLE
#1 - Still enclose inline code blocks in <code> tags…

### DIFF
--- a/lib/kramdown/converter/html_patch.rb
+++ b/lib/kramdown/converter/html_patch.rb
@@ -53,9 +53,9 @@ module Kramdown
           if lang.present?
             "<code class=\"#{CGI.escapeHTML(lang)} syntaxhl\">" +
               Redmine::SyntaxHighlighting.highlight_by_language(el.value, lang) +
-              '</code>'
+            "</code>"
           else
-            CGI.escapeHTML(el.value)
+            "<code>" + CGI.escapeHTML(el.value) + "</code>"
           end
         end
       end


### PR DESCRIPTION
…even if the syntax highlighting isn't present or else backticks still appear as plaintext

Signed-off-by: John Dimeo <dimeo@elderresearch.com>